### PR TITLE
feat: frontend docker deploy pipeline for coolify

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.git
+.github
+.vscode
+.idea
+*.log
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 VITE_API_URL=http://localhost:5132
-VITE_CHATBOT_URL=https://lucasdepetris.duckdns.org:8080
+VITE_CHATBOT_URL=http://localhost:8080

--- a/.github/workflows/frontend-cd.yml
+++ b/.github/workflows/frontend-cd.yml
@@ -1,0 +1,63 @@
+name: frontend-cd
+
+on:
+  push:
+    branches: ["master"]
+    paths:
+      - "src/**"
+      - "public/**"
+      - "index.html"
+      - "package.json"
+      - "package-lock.json"
+      - "vite.config.js"
+      - "postcss.config.js"
+      - "tailwind.config.js"
+      - "eslint.config.js"
+      - "Dockerfile"
+      - "nginx.conf"
+      - ".dockerignore"
+      - ".github/workflows/frontend-cd.yml"
+      - "!**/*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.REGISTRY_HOST }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build and push image (frontend)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
+          build-args: |
+            VITE_API_URL=${{ vars.FRONTEND_VITE_API_URL }}
+            VITE_CHATBOT_URL=${{ vars.FRONTEND_VITE_CHATBOT_URL }}
+          tags: |
+            ${{ vars.REGISTRY_HOST }}/${{ vars.FRONTEND_IMAGE }}:sha-${{ github.sha }}
+            ${{ vars.REGISTRY_HOST }}/${{ vars.FRONTEND_IMAGE }}:latest
+
+      - name: Trigger deploy (Coolify)
+        env:
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          COOLIFY_DEPLOY_URL: ${{ vars.COOLIFY_FRONTEND_DEPLOY_URL }}
+        run: |
+          curl -fsS -H "Authorization: Bearer ${COOLIFY_TOKEN}" "${COOLIFY_DEPLOY_URL}" > /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ COPY --from=build /app/dist ./
 
 EXPOSE 80
 
-HEALTHCHECK --interval=10s --timeout=3s --retries=5 CMD wget -q -O /dev/null http://localhost/health || exit 1
+HEALTHCHECK --interval=10s --timeout=3s --retries=5 CMD curl -fsS http://127.0.0.1/health > /dev/null || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+ARG VITE_API_URL=http://localhost:5132
+ARG VITE_CHATBOT_URL=http://localhost:8080
+ENV VITE_API_URL=${VITE_API_URL}
+ENV VITE_CHATBOT_URL=${VITE_CHATBOT_URL}
+
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+WORKDIR /usr/share/nginx/html
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist ./
+
+EXPOSE 80
+
+HEALTHCHECK --interval=10s --timeout=3s --retries=5 CMD wget -q -O /dev/null http://localhost/health || exit 1
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location = /health {
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,9 @@ import ProtectedRoutes from "./routes/ProtectedRoutes";
 function App() {
   // Estado simple de login
   const [login, setLogin] = useState(!!localStorage.getItem("token"));
+  const rawBasePath = import.meta.env.VITE_BASE_PATH || "/";
+  const routerBaseName =
+    rawBasePath === "/" ? "/" : rawBasePath.replace(/\/+$/, "");
 
   const cambiarLogin = () => {
     const token = localStorage.getItem("token");
@@ -32,7 +35,7 @@ function App() {
 
   return (
     <ThemeProvider>
-      <BrowserRouter basename="/PF-ISI-FRONT">
+      <BrowserRouter basename={routerBaseName}>
         <Routes>
           {/* RUTAS PÚBLICAS
             Todas estas rutas comparten el Navbar y el fondo del PublicLayout 

--- a/src/helpers/faqApi.js
+++ b/src/helpers/faqApi.js
@@ -1,8 +1,7 @@
 import axios from "axios";
 import { CHATBOT_URL } from "./config";
-const API_BASE_URL = CHATBOT_URL;
 
-// const API_BASE_URL = "https://lucasdepetris.duckdns.org:8080";
+const API_BASE_URL = CHATBOT_URL;
 
 export const getFaqs = async () => {
   try {
@@ -14,46 +13,6 @@ export const getFaqs = async () => {
     return response.data;
   } catch (error) {
     console.error("Error al obtener faqs:", error);
-    // Agrega un log aquí para debuggear
-    console.log("Error en la solicitud de faqs:", error);
     throw error;
   }
 };
-/* ---------------------TODO: ANALIZAR DE AGREGAR CON LE DB DE LUCAS--------
-import axios from 'axios';
-
-const baseURL = 'http://localhost:7122/api/Faq'; // Ajusta la URL a tu controlador de FAQs
-
-// Obtener todas
-export const getFaqs = async () => {
-  const response = await axios.get(`${baseURL}`);
-  return response.data;
-};
-
-// Crear nueva
-export const postFaq = async (data) => {
-  const token = localStorage.getItem("token");
-  const response = await axios.post(`${baseURL}`, data, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
-  return response.data;
-};
-
-// Editar existente
-export const putFaq = async (id, data) => {
-  const token = localStorage.getItem("token");
-  const response = await axios.put(`${baseURL}/${id}`, data, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
-  return response.data;
-};
-
-// Eliminar
-export const deleteFaq = async (id) => {
-  const token = localStorage.getItem("token");
-  const response = await axios.delete(`${baseURL}/${id}`, {
-    headers: { Authorization: `Bearer ${token}` }
-  });
-  return response.data;
-};
-*/

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,5 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
-  base: "/PF-ISI-FRONT/", // Asegúrate de usar el nombre exacto de tu repositorio
+  base: process.env.VITE_BASE_PATH || "/",
 });


### PR DESCRIPTION
## Resumen
- agrega deploy de frontend por contenedor (Docker + Nginx) para Coolify
- agrega workflow `frontend-cd.yml` para build/push/deploy en push a `master`
- excluye cambios solo `.md` para no disparar deploy
- agrega endpoint de health (`/health`) en Nginx para healthcheck de Coolify

## Fixes incluidos en este mismo PR
- elimina hardcode de basename de React Router (`/PF-ISI-FRONT`) y lo hace configurable por `VITE_BASE_PATH` (default `/`)
- corrige `vite.config.js` para usar base configurable (default `/`)
- ajusta healthcheck del contenedor a `127.0.0.1` para evitar falso `unhealthy` por resolución IPv6 de `localhost`
- limpia referencias legacy hardcodeadas en `faqApi` y `.env.example`

## Validación local
- `docker build -f Dockerfile -t infotrack-frontend:local .` OK
- contenedor levantado en `:8088` OK
- `GET /health` -> `ok`
- `index.html` sirve assets en `/assets/*` (sin prefijo hardcodeado del repo)

## Pendiente después del PR
- configurar vars/secrets del repo para ejecutar CD
- conectar webhook de deploy con app frontend en Coolify