### PR TITLE
fix: endpoints FAQ/health del chatbot en frontend

### DIFF
--- a/src/helpers/faqApi.js
+++ b/src/helpers/faqApi.js
@@ -5,7 +5,7 @@ const API_BASE_URL = CHATBOT_URL;
 
 export const getFaqs = async () => {
   try {
-    const response = await axios.get(`${API_BASE_URL}/faq`, {
+    const response = await axios.get(`${API_BASE_URL}/faq/`, {
       headers: {
         "Content-Type": "application/json",
       },

--- a/src/helpers/verificationConnection.js
+++ b/src/helpers/verificationConnection.js
@@ -5,8 +5,8 @@ const API_BASE_URL = CHATBOT_URL;
 
 export const verificarConexionChat = async () => {
   try {
-    // Realiza la solicitud GET al endpoint /chatbot/ping
-    const response = await axios.get(`${API_BASE_URL}/chatbot/ping`);
+    // Health endpoint canónico del chatbot.
+    const response = await axios.get(`${API_BASE_URL}/health`);
     if (response.status === 200) {
       console.log("El chatbot está en línea.");
     }


### PR DESCRIPTION
## Cambios
- Usa `/faq/` en lugar de `/faq` para evitar redirect 307 con downgrade de esquema.
- Usa `/health` en lugar de `/chatbot/ping` (endpoint canonico vigente).

## Resultado
- Evita error en FAQ por redirect.
- Evita 404 en verificacion de chatbot.
