### PR TITLE
fix: mostrar error de legajo duplicado en tiempo real

### DIFF
--- a/src/helpers/filaApi.js
+++ b/src/helpers/filaApi.js
@@ -57,12 +57,24 @@ export const postTurnoEnFila = async (legajo, idTramite) => {
     if (error?.code === SERVICE_ERROR_CODES.CONFIG_MISSING) {
       throw error;
     }
+    const backendMessage = error?.response?.data;
+    if (typeof backendMessage === "string" && backendMessage.trim().length > 0) {
+      throw new Error(backendMessage);
+    }
     throw createServiceError(
       SERVICE_ERROR_CODES.SERVICE_UNAVAILABLE,
       "El servicio de turnos no está disponible.",
       error
     );
   }
+};
+
+export const validarLegajoDisponible = async (legajo) => {
+  ensureBackendConfigured();
+  const response = await axios.get(`${API_BASE_URL}/api/Fila/ValidarLegajoDisponible`, {
+    params: { legajo },
+  });
+  return response.data;
 };
 
 export const personasAdelanteEnLaFila = async (idTurno) => {


### PR DESCRIPTION
## Objetivo
Mostrar al usuario el error de legajo duplicado antes de confirmar turno.

## Cambios
- Nueva llamada `validarLegajoDisponible` en `filaApi`.
- En `FilaScreen` se valida al completar 5 dígitos.
- Se bloquea confirmar mientras valida o si hay error.
- Si backend devuelve mensaje de negocio en el submit, se muestra ese mensaje.

## Validación
- Build OK: `npm run build`.