### PR TITLE
docs: README frontend alineado al formato del backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,83 @@
-# React + Vite
+# PF-ISI-FRONT
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+[![Frontend CD](https://github.com/danielarodiaz/PF-ISI-FRONT/actions/workflows/frontend-cd.yml/badge.svg?branch=master)](https://github.com/danielarodiaz/PF-ISI-FRONT/actions/workflows/frontend-cd.yml)
 
-Currently, two official plugins are available:
+Frontend de InfoTrack (React + Vite).
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Arquitectura rápida
+
+- App SPA: React + Vite
+- Build de producción: archivos estáticos en `dist/`
+- Runtime en contenedor: Nginx (`nginx.conf`)
+- Deploy: Coolify (imagen Docker publicada desde GitHub Actions)
+
+## Estructura
+
+- `src/`: aplicación React (pantallas, helpers, componentes)
+- `public/`: assets públicos
+- `Dockerfile`: build multi-stage + Nginx para servir SPA
+- `nginx.conf`: configuración de servidor para rutas SPA
+- `.github/workflows/frontend-cd.yml`: pipeline de build, push y deploy
+
+## Levantar local
+
+1. Copiar variables base:
+
+```bash
+cp .env.example .env
+```
+
+2. Instalar dependencias:
+
+```bash
+npm install
+```
+
+3. Ejecutar en desarrollo:
+
+```bash
+npm run dev
+```
+
+4. Build local:
+
+```bash
+npm run build
+```
+
+## Variables de entorno
+
+El frontend usa variables `VITE_` (ver `.env.example`):
+
+- `VITE_API_URL`: URL pública del backend .NET
+- `VITE_CHATBOT_URL`: URL pública del chatbot API
+
+Estas variables se inyectan en build:
+
+- Local: desde `.env`
+- CI/CD: desde GitHub Variables (`FRONTEND_VITE_API_URL`, `FRONTEND_VITE_CHATBOT_URL`)
+
+## CI/CD y deploy
+
+Workflow: `.github/workflows/frontend-cd.yml`
+
+- Trigger: push a `master` (excluye cambios solo en `.md`)
+- Build de imagen Docker con cache Buildx (`type=gha`)
+- Push al registry privado (`REGISTRY_HOST` + credenciales)
+- Trigger de deploy en Coolify (`COOLIFY_TOKEN` + `COOLIFY_FRONTEND_DEPLOY_URL`)
+
+Secrets/Variables esperadas en GitHub:
+
+- Secret: `REGISTRY_USERNAME`
+- Secret: `REGISTRY_PASSWORD`
+- Secret: `COOLIFY_TOKEN`
+- Variable: `REGISTRY_HOST`
+- Variable: `FRONTEND_IMAGE`
+- Variable: `COOLIFY_FRONTEND_DEPLOY_URL`
+- Variable: `FRONTEND_VITE_API_URL`
+- Variable: `FRONTEND_VITE_CHATBOT_URL`
+
+## Notas
+
+- Si falta `VITE_API_URL` o `VITE_CHATBOT_URL`, la app muestra mensajes de servicio no configurado en los módulos correspondientes.
+- El flujo de turnos públicos persiste referencia del turno en cliente para recuperación de sesión por `publicToken`.


### PR DESCRIPTION
## Objetivo
Alinear el README del frontend con la estructura/documentación del backend.

## Cambios
- Badge de workflow
- Arquitectura rápida
- Estructura del repo
- Guía local (env/install/dev/build)
- Variables de entorno y cómo se inyectan
- Flujo CI/CD y deploy con Coolify
- Notas operativas

## Resultado
README del frontend consistente con el estándar del proyecto.