### PR TITLE
feat: limitar solicitud de turno por dispositivo

### DIFF
--- a/src/helpers/deviceId.js
+++ b/src/helpers/deviceId.js
@@ -1,0 +1,16 @@
+const DEVICE_ID_KEY = "infotrackDeviceId";
+
+const fallbackRandomId = () =>
+  `dev-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+
+export const getOrCreateDeviceId = () => {
+  const existing = localStorage.getItem(DEVICE_ID_KEY);
+  if (existing) return existing;
+
+  const generated = typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : fallbackRandomId();
+
+  localStorage.setItem(DEVICE_ID_KEY, generated);
+  return generated;
+};

--- a/src/helpers/filaApi.js
+++ b/src/helpers/filaApi.js
@@ -43,12 +43,13 @@ export const getFila = async () => {
   }
 };
 
-export const postTurnoEnFila = async (legajo, idTramite) => {
+export const postTurnoEnFila = async (legajo, idTramite, deviceId) => {
   try {
     ensureBackendConfigured();
     const turnoData = {
       legajo: legajo,
-      idTramite: idTramite
+      idTramite: idTramite,
+      deviceId: deviceId,
     };
     const response = await axios.post(`${API_BASE_URL}/api/Fila/AgregarTurnoAFila`, turnoData);
     return response.data;


### PR DESCRIPTION
## Objetivo
Evitar que un mismo dispositivo solicite más de un turno activo y mejorar UX en `/fila`.

## Cambios
- Nuevo helper `deviceId` persistente en localStorage (`infotrackDeviceId`).
- `postTurnoEnFila` envía `deviceId` al backend.
- En `/fila`, si hay turno activo en storage, redirige a `/turno`.
- Si backend bloquea por dispositivo activo, muestra mensaje claro.
- Se mantiene validación de legajo existente en fila.

## Validación
- Build frontend OK: `npm run build`.
