### PR TITLE
fix: mostrar mensajes amigables para errores de creación de turno

### DIFF
--- a/src/helpers/deviceId.js
+++ b/src/helpers/deviceId.js
@@ -4,13 +4,17 @@ const fallbackRandomId = () =>
   `dev-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
 
 export const getOrCreateDeviceId = () => {
-  const existing = localStorage.getItem(DEVICE_ID_KEY);
-  if (existing) return existing;
+  try {
+    const existing = localStorage.getItem(DEVICE_ID_KEY);
+    if (existing) return existing;
 
-  const generated = typeof crypto !== "undefined" && crypto.randomUUID
-    ? crypto.randomUUID()
-    : fallbackRandomId();
+    const generated = typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : fallbackRandomId();
 
-  localStorage.setItem(DEVICE_ID_KEY, generated);
-  return generated;
+    localStorage.setItem(DEVICE_ID_KEY, generated);
+    return generated;
+  } catch {
+    return fallbackRandomId();
+  }
 };

--- a/src/helpers/filaApi.js
+++ b/src/helpers/filaApi.js
@@ -58,9 +58,12 @@ export const postTurnoEnFila = async (legajo, idTramite, deviceId) => {
     if (error?.code === SERVICE_ERROR_CODES.CONFIG_MISSING) {
       throw error;
     }
-    const backendMessage = error?.response?.data;
+    const backendPayload = error?.response?.data;
+    const backendMessage = typeof backendPayload === "string"
+      ? backendPayload
+      : backendPayload?.detail || backendPayload?.message || "";
     if (typeof backendMessage === "string" && backendMessage.trim().length > 0) {
-      throw new Error(backendMessage);
+      throw new Error(backendMessage.trim());
     }
     throw createServiceError(
       SERVICE_ERROR_CODES.SERVICE_UNAVAILABLE,

--- a/src/pages/FilaScreen.jsx
+++ b/src/pages/FilaScreen.jsx
@@ -154,6 +154,8 @@ const FilaScreen = () => {
         setServiceError(`${error.message} Si recargaste o cambiaste navegador, vuelve con el link de tu turno activo.`);
       } else if (error?.message?.includes("legajo ya se encuentra en la fila")) {
         setErrorLegajo(error.message);
+      } else if (error?.message) {
+        setServiceError(error.message);
       } else {
         setServiceError("No se pudo solicitar el turno. Intenta nuevamente en unos minutos.");
       }


### PR DESCRIPTION
## Objetivo
Mostrar errores entendibles para usuario final en la solicitud de turno.

## Cambios
- `filaApi`: parsea `ProblemDetails` (`detail`) además de texto plano.
- `FilaScreen`: muestra mensaje del backend cuando aplica.
- `deviceId`: fallback robusto si localStorage no está disponible.

## Validación
- `npm run build` OK.