### PR TITLE
feat(auth): hardening de sesión admin con refresh/logout

### DIFF
--- a/src/helpers/authStorage.js
+++ b/src/helpers/authStorage.js
@@ -1,0 +1,19 @@
+const ACCESS_TOKEN_KEY = "token";
+const REFRESH_TOKEN_KEY = "refreshToken";
+
+export const getAccessToken = () => localStorage.getItem(ACCESS_TOKEN_KEY);
+
+export const getRefreshToken = () => localStorage.getItem(REFRESH_TOKEN_KEY);
+
+export const saveAuthTokens = (tokens) => {
+  if (!tokens?.token) return;
+  localStorage.setItem(ACCESS_TOKEN_KEY, tokens.token);
+  if (tokens.refreshToken) {
+    localStorage.setItem(REFRESH_TOKEN_KEY, tokens.refreshToken);
+  }
+};
+
+export const clearAuthTokens = () => {
+  localStorage.removeItem(ACCESS_TOKEN_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
+};

--- a/src/helpers/login.js
+++ b/src/helpers/login.js
@@ -1,36 +1,68 @@
 import axios from "axios";
 import { BACKEND_URL } from "./config";
+import { clearAuthTokens, getAccessToken, getRefreshToken, saveAuthTokens } from "./authStorage";
+
 const API_BASE_URL = BACKEND_URL;
 
 export const LogIn = async (user, password) => {
-    try {
-        const response = await axios.post(`${API_BASE_URL}/api/Autenticacion/LogIn`, {
-            user: user,
-            password: password
-        }, {
-            headers: {
-                "Content-Type": "application/json",
-            },
-        });
-        console.log("Token obtenido:", response.data);
-        return response.data;
-    } catch (error) {
-        console.error("Error al obtener token:", error);
-        // Agrega un log aquí para debuggear
-        console.log("Error en la solicitud de token:", error);
-        throw error;
-    }
+  const response = await axios.post(`${API_BASE_URL}/api/Autenticacion/LogIn`, {
+    user,
+    password,
+  }, {
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  return response.data;
 };
 
 export const verificarToken = async (token) => {
-    //console.log("Enviando solicitud de verificación de token con:", token);
-    const response = await axios.post(`${API_BASE_URL}/api/Autenticacion/ValidarToken`, JSON.stringify(token), {
-        headers: {
-            "Content-Type": "application/json",
-            "accept": "*/*"
-        },
+  const response = await axios.post(
+    `${API_BASE_URL}/api/Autenticacion/ValidarToken`,
+    JSON.stringify(token),
+    {
+      headers: {
+        "Content-Type": "application/json",
+        accept: "*/*",
+      },
+    }
+  );
+  return Boolean(response?.data?.valid);
+};
+
+export const refrescarSesion = async () => {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) return false;
+
+  try {
+    const response = await axios.post(`${API_BASE_URL}/api/Autenticacion/Refresh`, {
+      refreshToken,
     });
-   // console.log("Respuesta de la solicitud de verificación de token:", response);
-    //console.log("Token verificado:", response.data);
-    return response.data;
+    if (response?.data?.token) {
+      saveAuthTokens(response.data);
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+export const cerrarSesion = async () => {
+  const token = getAccessToken();
+  if (!token) return;
+
+  try {
+    await axios.post(
+      `${API_BASE_URL}/api/Autenticacion/Logout`,
+      {},
+      { headers: { Authorization: `Bearer ${token}` } }
+    );
+  } catch {
+    // no-op: al cerrar sesión del cliente igual se deben limpiar tokens
+  }
+};
+
+export const cerrarSesionLocal = () => {
+  clearAuthTokens();
 };

--- a/src/pages/LoginAdmin.jsx
+++ b/src/pages/LoginAdmin.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import Swal from "sweetalert2";
 import { LogIn } from "../helpers/login";
+import { saveAuthTokens } from "../helpers/authStorage";
 import { User, Lock, LogIn as LogInIcon } from "lucide-react"; // Iconos modernos
 import { useTheme } from "../context/ThemeContext";
 
@@ -28,9 +29,9 @@ const LoginAdmin = ({ cambiarLogin }) => {
 
     setLoading(true);
     try {
-      const token = await LogIn(user, password);
-      if (token) {
-        localStorage.setItem("token", token.token);
+      const authResponse = await LogIn(user, password);
+      if (authResponse?.token) {
+        saveAuthTokens(authResponse);
         cambiarLogin();
         navigate("/admin/homeAdmin");
       } else {

--- a/src/routes/ProtectedRoutes.jsx
+++ b/src/routes/ProtectedRoutes.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { Navigate, useLocation, useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
-import { verificarToken } from "../helpers/login";
+import { cerrarSesionLocal, refrescarSesion, verificarToken } from "../helpers/login";
+import { getAccessToken } from "../helpers/authStorage";
 import Swal from "sweetalert2";
 
 const ProtectedRoutes = ({ children }) => {
@@ -10,23 +11,11 @@ const ProtectedRoutes = ({ children }) => {
   const location = useLocation();
   const navigate = useNavigate();
 
-  console.log("[admin-debug][ProtectedRoutes] render", {
-    path: location.pathname,
-    isLoading,
-    isAuthenticated,
-    hasToken: !!localStorage.getItem("token"),
-  });
-
   useEffect(() => {
     const checkToken = async () => {
-      const token = localStorage.getItem("token");
-      console.log("[admin-debug][ProtectedRoutes] checkToken:start", {
-        path: location.pathname,
-        hasToken: !!token,
-      });
+      const token = getAccessToken();
       
       if (!token) {
-        console.log("[admin-debug][ProtectedRoutes] checkToken:no-token");
         setIsAuthenticated(false);
         setIsLoading(false);
         return;
@@ -34,40 +23,26 @@ const ProtectedRoutes = ({ children }) => {
 
       try {
         const valido = await verificarToken(token);
-        console.log("[admin-debug][ProtectedRoutes] checkToken:response", {
-          valido,
-        });
-        
-        if (!valido) {
-          Swal.fire({
-            icon: "error",
-            title: "Oops...",
-            text: "Expiró tu sesión. Vuelve a iniciar sesión para continuar",
-          }).then(() => {
-            localStorage.removeItem("token");
-            navigate("/loginAdmin");
-          });
-          //localStorage.removeItem("token");
-          setIsAuthenticated(false);
-        } else {
-          console.log("[admin-debug][ProtectedRoutes] checkToken:authenticated");
+        if (valido) {
           setIsAuthenticated(true);
+          return;
         }
+
+        const refreshed = await refrescarSesion();
+        if (!refreshed) throw new Error("session refresh failed");
+        setIsAuthenticated(true);
       } catch (error) {
-        console.error("[admin-debug][ProtectedRoutes] checkToken:error", error);
+        console.error("Error verifying token:", error);
         Swal.fire({
           icon: "error",
           title: "Oops...",
           text: "Expiró tu sesión. Vuelve a iniciar sesión para continuar",
         }).then(() => {
-          localStorage.removeItem("token");
+          cerrarSesionLocal();
           navigate("/loginAdmin"); // Redirigir sin recargar la página
         });
-        //console.error("Error verifying token:", error);
-        //localStorage.removeItem("token");
         setIsAuthenticated(false);
       } finally {
-        console.log("[admin-debug][ProtectedRoutes] checkToken:finally");
         setIsLoading(false);
       }
     };
@@ -76,17 +51,14 @@ const ProtectedRoutes = ({ children }) => {
   }, [location.pathname, navigate]); // Re-verify when path changes in protected routes
 
   if (isLoading) {
-    console.log("[admin-debug][ProtectedRoutes] loading-screen");
     // You could return a loading spinner here
     return <div className="text-center py-5">Verificando acceso...</div>;
   }
 
   if (!isAuthenticated) {
-    console.log("[admin-debug][ProtectedRoutes] redirect-login");
     return <Navigate to="/loginAdmin" />;
   }
 
-  console.log("[admin-debug][ProtectedRoutes] allow-children");
   return children;
 };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  base: process.env.VITE_BASE_PATH || "/",
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, ".", "");
+  return {
+    plugins: [react()],
+    base: env.VITE_BASE_PATH || "/",
+  };
 });


### PR DESCRIPTION
## Resumen
- agrega storage de sesión para token y refreshToken
- adapta login admin para persistir ambos tokens
- agrega refresh automático en requests que devuelven 401
- fortalece ProtectedRoutes para reintento por refresh antes de expirar sesión
- integra logout explícito contra backend antes de limpiar sesión local
- corrige vite.config.js para leer env sin process (lint compatible)

## Archivos principales
- src/helpers/authStorage.js
- src/helpers/login.js
- src/services/api.js
- src/routes/ProtectedRoutes.jsx
- src/pages/LoginAdmin.jsx
- src/pages/HomeAdmin.jsx
- vite.config.js

## Validación
- npm run lint (sin errores; warnings preexistentes de hooks)
- npm run build (ok)

## Notas
- este PR asume backend con endpoints LogIn, Refresh, Logout y ValidarToken activos.
